### PR TITLE
Make four-card layout reusable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7931,15 +7931,6 @@
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-length": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
@@ -7974,6 +7965,15 @@
             "ansi-regex": "3.0.0"
           }
         }
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "strip-ansi": {

--- a/src/components/RouteCards.vue
+++ b/src/components/RouteCards.vue
@@ -1,0 +1,37 @@
+<template lang="pug">
+  v-layout(row wrap)
+    v-flex(v-for="(card, idx) in cards" :key="idx" xs12 md6)
+      v-card(:to="card.route" dark="dark")
+        v-card-media(:height="cardHeight" :src="card.img")
+          v-container(fill-height fluid): v-flex(xs12).white--text.darken-background
+            .headline.text-xs-center {{ card.title }}
+            .subheading.text-xs-center {{ card.text }}
+</template>
+
+<style lang="stylus" scoped>
+.darken-background
+  background: rgba(0, 0, 0, 0.4)
+</style>
+
+
+<script>
+export default {
+  props: {
+    cards: {
+      type: Array,
+      validator (value) {
+        if (value.length % 2 !== 0) return false
+        return value.every(card => card.img && card.route && card.title && card.text)
+      }
+    },
+    cardHeight: {
+      type: Number,
+      default: 300
+    },
+    dark: {
+      type: Boolean,
+      default: false
+    }
+  }
+}
+</script>

--- a/src/routes/AsyncDemo.vue
+++ b/src/routes/AsyncDemo.vue
@@ -1,17 +1,17 @@
--<template lang="pug">
--  div
--    p The below is the response to a GET request to #[code api/debug/echo].
--    code(v-if="echo") {{ echo }}
--    p(v-else) Loading...
--</template>
--
--<script>
--export default {
--  asyncComputed: {
--    async echo () {
--      let echo = await this.$http.get('debug/echo')
--      return JSON.stringify(echo, null, 2)
--    }
--  }
--}
--</script>
+<template lang="pug">
+  div
+    p The below is the response to a GET request to #[code api/debug/echo].
+    code(v-if="echo") {{ echo }}
+    p(v-else) Loading...
+</template>
+
+<script>
+export default {
+  asyncComputed: {
+    async echo () {
+      let echo = await this.$http.get('debug/echo')
+      return JSON.stringify(echo, null, 2)
+    }
+  }
+}
+</script>

--- a/src/routes/home.vue
+++ b/src/routes/home.vue
@@ -1,83 +1,41 @@
 <template>
-  <v-layout row wrap>
-    <v-flex xs12 md6>
-      <v-card>
-        <v-card-media
-          class="white--text"
-          height="256px"
-          src="http://icons.iconarchive.com/icons/icons8/android/256/Users-Student-icon.png"
-        >
-          <v-container fill-height fluid>
-            <v-layout fill-height>
-              <v-flex xs12 align-end flexbox>
-                <span class="headline">Students<br></span>
-                <span id="student_text" class="red--text">Meet computing students and learn about opportunities available to students through CinC</span>
-              </v-flex>
-            </v-layout>
-          </v-container>
-        </v-card-media>
-      </v-card>
-    </v-flex>
-    <v-flex xs12 md6>
-      <v-card>
-        <v-card-media
-          class="white--text"
-          height="256px"
-          src="http://icons.iconarchive.com/icons/icons8/android/256/Users-Student-icon.png"
-        >
-          <v-container fill-height fluid>
-            <v-layout fill-height>
-              <v-flex xs12 align-end flexbox>
-                <span class="headline">Faculty<br></span>
-                <span id="faculty_text" class="red--text">Meet the great faculty who make CinC possible</span>
-              </v-flex>
-            </v-layout>
-          </v-container>
-        </v-card-media>
-      </v-card>
-    </v-flex>
-    <v-flex xs12 md6>
-      <v-card>
-        <v-card-media
-          class="white--text"
-          height="256px"
-          src="http://icons.iconarchive.com/icons/icons8/android/256/Users-Student-icon.png"
-        >
-          <v-container fill-height fluid>
-            <v-layout fill-height>
-              <v-flex xs12 align-end flexbox>
-                <span class="headline">Courses<br></span>
-                <span id="courses_text" class="red--text">Learn about the great computing courses already on offer, or give input on new courses</span>
-              </v-flex>
-            </v-layout>
-          </v-container>
-        </v-card-media>
-      </v-card>
-    </v-flex>
-    <v-flex xs12 md6>
-      <v-card>
-        <v-card-media
-          class="white--text"
-          height="256px"
-          src="http://icons.iconarchive.com/icons/icons8/android/256/Users-Student-icon.png"
-        >
-          <v-container fill-height fluid>
-            <v-layout fill-height>
-              <v-flex xs12 align-end flexbox>
-                <span class="headline">Partners<br></span>
-                <span id="partners_text" class="red--text">Learn about the partners who make the initiative possible, or become a partner</span>
-              </v-flex>
-            </v-layout>
-          </v-container>
-        </v-card-media>
-      </v-card>
-    </v-flex>
-  </v-layout>
+  <RouteCards :cards="cards"></RouteCards>
 </template>
 
 <script>
-  export default {
-    data () {
+import RouteCards from '@/components/RouteCards'
+
+export default {
+  data () {
+    return {
+      cards: [
+        {
+          img: 'https://images.pexels.com/photos/265076/pexels-photo-265076.jpeg',
+          route: '/students/',
+          title: 'Students',
+          text: 'Meet computing students and learn about opportunities available to students through CinC'
+        },
+        {
+          img: 'https://images.pexels.com/photos/159935/pexels-photo-159935.jpeg',
+          route: '/faculty/',
+          title: 'Faculty',
+          text: 'Meet the great faculty who make CinC possible'
+        },
+        {
+          img: 'https://images.pexels.com/photos/12064/pexels-photo-12064.jpeg',
+          route: '/courses/',
+          title: 'Courses',
+          text: 'Learn about the great computing courses already on offer, or give input on new courses'
+        },
+        {
+          img: 'https://images.pexels.com/photos/630835/pexels-photo-630835.jpeg?w=1260&h=750&auto=compress&cs=tinysrgb',
+          route: '/partners/',
+          title: 'Partners',
+          text: 'Learn about the partners who make the initiative possible, or become a partner'
+        }
+      ]
     }
-  }
+  },
+  components: { RouteCards }
+}
 </script>


### PR DESCRIPTION
Also grab some free stock photo links for temp images.

Yes, this touches everything, but it's a direct modification of what you had. I tried using slots but it didn't work, so I came up with this design instead. What do you think?

If we want to stick a feed in here, we can wrap the `<RouteCards>` element in another flex context. But I'm starting to think that the feed will be beside the drop content, in a 2/1 arrangement.