### PR TITLE
Improve list-group unfold behavior

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -2,15 +2,14 @@
   v-app
     v-navigation-drawer(app v-model="drawer" persistent enable-resize-watcher)
       v-list(dense)
-        v-list-tile(to="/" exact @click="closeGroups")
+        v-list-tile(to="/" exact)
           v-list-tile-action: v-icon home
           v-list-tile-content: v-list-tile-title Home
-        //- TODO: cancel click when already open?
-        v-list-tile(to="/blog/" @click="closeGroups")
+        v-list-tile(to="/blog/")
           v-list-tile-action: v-icon book
           v-list-tile-content: v-list-tile-title Blog
         v-list-group(v-for="(group, idx) in groups", v-model="group.active" :key="idx")
-          v-list-tile(slot="item" :to="group.to")
+          v-list-tile(slot="item" :to="group.to" @click.stop="")
             v-list-tile-action: v-icon {{ group.icon }}
             v-list-tile-content: v-list-tile-title {{ group.title }}
             v-list-tile-action: v-icon keyboard_arrow_down
@@ -36,19 +35,17 @@ export default {
           to: '/students/',
           icon: 'school',
           title: 'Students',
-          active: this.$route.path.startsWith('/students/'),
           paths: [
-            { to: '/students/projects/', title: 'Projects', icon: "list" },
-            { to: '/students/experiences/', title: 'Experiences', icon: "map" },
-            { to: '/students/courses/', title: 'Courses', icon: "assignment" },
-            { to: '/students/awards/', title: 'Awards', icon: "star_border" }
+            { to: '/students/projects/', title: 'Projects', icon: 'list' },
+            { to: '/students/experiences/', title: 'Experiences', icon: 'map' },
+            { to: '/students/courses/', title: 'Courses', icon: 'assignment' },
+            { to: '/students/awards/', title: 'Awards', icon: 'star_border' }
           ]
         },
         {
           to: '/faculty/',
           icon: 'fa-file-text',
           title: 'Faculty',
-          active: this.$route.path.startsWith('/faculty/'),
           paths: [
             { to: '/faculty/student_fellows/', title: 'Student Fellows' },
             { to: '/faculty/teaching_fellows/', title: 'Teaching Fellows' },
@@ -62,14 +59,19 @@ export default {
     }
   },
   methods: {
-    closeGroups () {
-      this.groups.forEach(group => {
-        group.active = false
-      })
-    },
     toggleDrawer () {
       this.drawer = !this.drawer
     }
+  },
+  created () {
+    this.$router.afterEach((to, from) => {
+      this.groups.forEach(group => {
+        group.active = to.path.startsWith(group.to)
+      })
+    })
+    this.groups.forEach(group => {
+      group.active = this.$route.path.startsWith(group.to)
+    })
   }
 }
 </script>


### PR DESCRIPTION
- Cannot close list-group by clicking on it again
- Group object doesn't have to remember to define active in the correct
  starting state
- Group unfold state is handled by a route changed callback